### PR TITLE
Downgrades firebase-admin-sdk to version 6.0.0 because of issues with…

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "ejs": "^2.6.1",
     "express": "^4.16.4",
     "file-base64": "1.0.0",
-    "firebase-admin": "^8.1.0",
+    "firebase-admin": "^6.0.0",
     "nyc": "^13.1.0",
     "promise": "7.1.1",
     "q": "^1.4.1",


### PR DESCRIPTION
… deployment on BBP machines